### PR TITLE
Fix for determining render size of an element

### DIFF
--- a/angular-collapse.js
+++ b/angular-collapse.js
@@ -41,10 +41,10 @@ angular.module('angular-collapse', [])
 				var size = {};
 				var clone = element.clone();
 				clone.css({"visibility":"visible", "display":"table"});
-				document.body.appendChild(clone[0]);
+				element[0].parentElement.appendChild(clone[0]);
 				size.width = clone[0].clientWidth;
 				size.height = clone[0].clientHeight;
-				document.body.removeChild(clone[0]);
+				element[0].parentElement.removeChild(clone[0]);
 				return size;
 			}
 


### PR DESCRIPTION
Proposed fix for https://github.com/plong0/angular-collapse/issues/1

getRenderSize() now temporarily inserts the cloned element in the same spot as the original so correct styles are always applied. This fixes the issue and doesn't seem to produce any side effects.
